### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ cache:
     - ~/.m2
 
 install: true
-script: mvn -q -B --global-toolchains travis-maven-toolchain.xml clean install -DskipTests &&
-        mvn -B --global-toolchains travis-maven-toolchain.xml -pl :org.eclipse.birt.core.tests integration-test
+script: mvn -B --global-toolchains travis-maven-toolchain.xml clean install -DskipTests | grep -E '\[WARNING\]|\[ERROR\]' &&
+        mvn -B --global-toolchains travis-maven-toolchain.xml -pl :org.eclipse.birt.core.tests integration-test | grep -E '\[WARNING\]|\[ERROR\]'
 before_cache:
   - rm -r ~/.m2/repository/org/eclipse/birt
   - rm -r ~/.m2/repository/.cache/tycho


### PR DESCRIPTION
The Travis build currently fails because maven is set to quite (to not exceed the travis build log) and so Travis does not get an output for 10mins.

This PR greps all maven log messages (omitting all other messages).